### PR TITLE
Ashish/pdf page going blank

### DIFF
--- a/projects/ng2-lean-pdf-viewer/src/lib/ng2-lean-pdf-viewer.component.ts
+++ b/projects/ng2-lean-pdf-viewer/src/lib/ng2-lean-pdf-viewer.component.ts
@@ -28,7 +28,6 @@ export class Ng2LeanPdfViewerComponent implements OnChanges {
   private resizeTimer: any;
   private pdfContainer!: HTMLElement;
   private pdfData!: PDFDocumentProxy;
-  private lastVisiblePageIndex = -1;
 
   constructor(private parentContainer: ElementRef, private renderer: Renderer2) {
     this.pdfContainer = this.renderer.createElement('div');
@@ -53,7 +52,6 @@ export class Ng2LeanPdfViewerComponent implements OnChanges {
 
   private loadPdf(input: CustomPDFInput): void {
     if (!Util.isEmptyItem(input.src)) {
-      this.lastVisiblePageIndex = -1;
       this.removeAllPageNodes();
       this.setPdfWorkerUrl(input);
       const loadParameters = this.getPdfLoadParameters(input); 
@@ -84,7 +82,6 @@ export class Ng2LeanPdfViewerComponent implements OnChanges {
   }
 
   private generatePages(pdf: PDFDocumentProxy): void {
-    this.lastVisiblePageIndex = -1;
     for (let i = 1; i <= pdf._pdfInfo.numPages; i++) {
       pdf.getPage(i).then(page => {
         const pdfContainer = this.pdfContainer;
@@ -118,7 +115,6 @@ export class Ng2LeanPdfViewerComponent implements OnChanges {
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
-          this.lastVisiblePageIndex = page.pageNumber;
           const canvasWrapper: HTMLCanvasElement = this.renderer.createElement('div');
           this.renderer.addClass(canvasWrapper, 'canvasWrapper');
           this.renderer.setStyle(canvasWrapper, 'width', `${viewport.width}px`);
@@ -143,16 +139,14 @@ export class Ng2LeanPdfViewerComponent implements OnChanges {
               this.renderer.appendChild(pageContainer, textLayerWrapper);
             });
           });
-        } else if(page.pageNumber !== this.lastVisiblePageIndex 
-                  && (page.pageNumber !== this.lastVisiblePageIndex - 1) 
-                    && (page.pageNumber !== this.lastVisiblePageIndex + 1)) {
+        } else {
           page.cleanup();
           page.destroyed = true;
           this.renderer.removeAttribute(pageContainer, 'data-loaded');
           Array.from(pageContainer.childNodes).forEach(child => this.renderer.removeChild(pageContainer, child));
         }
       }, {
-        threshold: [0.0]
+        threshold: [0, .1, .9, 1]
       });
     });
     observer.observe(pageContainer);


### PR DESCRIPTION
projects/ng2-lean-pdf-viewer/src/lib/ng2-lean-pdf-viewer.component.ts

Reverted:
Previous fix to detect pages visible in the viewport

New fix:
 - Persisting the 'lastVisiblePageIndex' to prevent it from getting destroyed from the DOM
 - Turning off the flag 'page.pendingCleanup' right before the page gets destroyed from the DOM