### PR TITLE
fix(es5-webpack-bug) : pointing import path for pdfjs-dist to es5 module

### DIFF
--- a/projects/ng2-lean-pdf-viewer/src/lib/ng2-lean-pdf-viewer.component.ts
+++ b/projects/ng2-lean-pdf-viewer/src/lib/ng2-lean-pdf-viewer.component.ts
@@ -3,7 +3,7 @@ import { Renderer2, SimpleChanges } from '@angular/core';
 
 import { PDFDocumentLoadingTask, PDFDocumentProxy, PDFPageProxy, TextContent } from 'pdfjs-dist/types/display/api';
 import { PageViewport } from 'pdfjs-dist/types/display/display_utils';
-import * as pdfjsLib from 'pdfjs-dist';
+import * as pdfjsLib from 'pdfjs-dist/es5/build/pdf';
 
 import { passwordResponses, unsupportedFeatures, logTypes } from './pdf.enums';
 import { CustomPDFInput, CustomPDFPage, OnProgressData } from './pdf.models';


### PR DESCRIPTION
Fixed breaking change from pdfjs-dist.


**Problem** 
With the 'ng2-lean-pdf-viewer' library installed, webpack module bundling fails for newer versions of Angular (ivy) with the following error :

`
Error: ./node_modules/pdfjs-dist/build/pdf.js 2205:45
Module parse failed: Unexpected token (2205:45)
File was processed with these loaders:
./node_modules/@angular-devkit/build-optimizer/src/build-optimizer/webpack-loader.js
You may need an additional loader to handle the result of these loaders.
         intent: renderingIntent,
         renderInteractiveForms: renderInteractiveForms === true,
         annotationStorage: annotationStorage?.serializable || null
     });
}
@ ./node_modules/@ashish-koshy/ng2-lean-pdf-viewer/__ivy_ngcc__/fesm2015/ashish-koshy-ng2-lean-pdf-viewer.js 2:0-39 150:36-56 229:28-52 271:16-44 271:100-116 274:16-44
@ ./src/app/app.module.ts
@ ./src/main.ts
@ multi ./src/main.ts
`


**Solution:**
Pointing to es5 module of 'pdfjs-dist'. Changed import path for 'pdfjs-dist' object from :
`pdfjs-dist`
to 
`pdfjs-dist/es5/build/pdf`